### PR TITLE
BNPPFSLA-842-ci-upgrade [Update] add ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,16 @@
-name: Java CI
-on: [push]
-
+name: 'Continuous Integration'
+on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps: # should be version 7...
-      - uses: actions/checkout@v3
+      - name: Check out
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'temurin'
+          java-version: 8
+          distribution: temurin
       - name: Build with Maven alfresco-value-assistance-share
         run: mvn clean install -f alfresco-value-assistance-share
       - name: Build with Maven alfresco-value-assistance-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: 'Continuous Integration'
 on: [ push, pull_request ]
 jobs:
-  build:
+  BuildAndPublish:
     runs-on: ubuntu-latest
     steps: # should be version 7...
       - name: Check out
@@ -9,9 +9,15 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: temurin
       - name: Build with Maven alfresco-value-assistance-share
         run: mvn clean install -f alfresco-value-assistance-share
       - name: Build with Maven alfresco-value-assistance-repo
         run: mvn clean install -f alfresco-value-assistance-repo
+      - name: Login to Docker
+        uses: docker/login-action@v2
+        with:
+          registry: private.docker.xenit.eu
+          username: ${{ secrets.CLOUDSMITH_USER }}
+          password: ${{ secrets.CLOUDSMITH_APIKEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-      - name: Build with Maven alfresco-value-assistance-share
-        run: mvn clean install -f alfresco-value-assistance-share
-      - name: Build with Maven alfresco-value-assistance-repo
-        run: mvn clean install -f alfresco-value-assistance-repo
+#      - name: Build with Maven alfresco-value-assistance-share
+#        run: mvn clean install -f alfresco-value-assistance-share
+#      - name: Build with Maven alfresco-value-assistance-repo
+#        run: mvn clean install -f alfresco-value-assistance-repo
       - name: Login to Docker
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,36 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
-#      - name: Build with Maven alfresco-value-assistance-share
-#        run: mvn clean install -f alfresco-value-assistance-share
-#      - name: Build with Maven alfresco-value-assistance-repo
-#        run: mvn clean install -f alfresco-value-assistance-repo
-      - name: Login to Docker
-        uses: docker/login-action@v2
+      - name: Get the release version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+#Try and set the version in the POMs of subprojects.
+#      - name: Update package version
+#        run: mvn versions:set -DnewVersion=${{ steps.get_version.outputs.VERSION }}
+
+      - name: Build with Maven alfresco-value-assistance-share
+        run: mvn clean install -f alfresco-value-assistance-share
+      - name: Build with Maven alfresco-value-assistance-repo
+        run: mvn clean install -f alfresco-value-assistance-repo
+      - run: mkdir staging && cp alfresco-value-assistance-share/target/*.jar staging && cp alfresco-value-assistance-share/target/*.amp staging
+      - run: cp alfresco-value-assistance-repo/target/*.jar staging && cp alfresco-value-assistance-repo/target/*.amp staging
+      # publishing.
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: Package
+#          path: staging
+
+      - name: Publish
+        uses: actions/upload-artifact@v3
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags/') }}
         with:
-          registry: private.docker.xenit.eu
-          username: ${{ secrets.CLOUDSMITH_USER }}
-          password: ${{ secrets.CLOUDSMITH_APIKEY }}
+          path: staging
+        env:
+          SIGNING_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.MAVEN_CENTRAL_GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.SONATYPE_S01_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.SONATYPE_S01_PASSWORD }}
+
+#https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Java CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps: # should be version 7...
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build with Maven alfresco-value-assistance-share
+        run: mvn clean install -f alfresco-value-assistance-share
+      - name: Build with Maven alfresco-value-assistance-repo
+        run: mvn clean install -f alfresco-value-assistance-repo


### PR DESCRIPTION
Upgrading BNPPF dependencies to push to mavencentral instead of Artifactory.xenit.
Adding a ci build.